### PR TITLE
Use Map instead of Properties for launch properties.

### DIFF
--- a/modules/org.pathvisio.launcher/src/org/pathvisio/launcher/PathVisioMain.java
+++ b/modules/org.pathvisio.launcher/src/org/pathvisio/launcher/PathVisioMain.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -112,14 +113,14 @@ public class PathVisioMain {
 	
 	private BundleContext context;
 		
-	private Properties getLaunchProperties()
+	private Map<String, String> getLaunchProperties()
 	{	
-		Properties launchProperties = new Properties();
+		Map<String, String> launchProperties = new HashMap<String, String>();
 		for (int i = 0; i < frameworkProperties.length; i++) {
-			launchProperties.setProperty(frameworkProperties[i][0], frameworkProperties[i][1]);
+			launchProperties.put(frameworkProperties[i][0], frameworkProperties[i][1]);
 		}
 		// hides the felix cache in .PathVisio/bundle-cache
-		launchProperties.setProperty("felix.cache.rootdir", getBundleCacheFile().getAbsolutePath());
+		launchProperties.put("felix.cache.rootdir", getBundleCacheFile().getAbsolutePath());
 		return launchProperties;
 	}
 	


### PR DESCRIPTION
The felix.jar and org.eclipse.osgi.jar in /lib are on different OSGI versions.  The code currently doesn't compile against felix.jar or the latest OSGI spec.

org.osgi.framework.launch.Framework.newFramework(map) expects a Map<String, String> but Properties is based on Hashtable<Object, Object>.

This change fixes that.